### PR TITLE
sync roles in docs and application

### DIFF
--- a/spring-resource-server/src/main/resources/application.properties
+++ b/spring-resource-server/src/main/resources/application.properties
@@ -15,7 +15,7 @@ keycloak.bearer-only=true
 keycloak.cors=true
 
 keycloak.securityConstraints[0].authRoles[0]=admin
-keycloak.securityConstraints[0].authRoles[1]=user
+keycloak.securityConstraints[0].authRoles[1]=project_manager
 keycloak.securityConstraints[0].securityCollections[0].name=user stuff
 keycloak.securityConstraints[0].securityCollections[0].patterns[0]=/me
 


### PR DESCRIPTION
We protected the /me endpoint for users with roles "admin" or "user", but in the readme we had "admin" and "project_manager".